### PR TITLE
Fix negative times

### DIFF
--- a/subsync.js
+++ b/subsync.js
@@ -44,7 +44,7 @@ function createShifter(specs) {
        var start = specs[k-1], end = specs[k];
        var percent = (pos - start.at) / (end.at - start.at)
        var shift = start.shift + percent * (end.shift - start.shift);
-       return pos + shift;
+       return (pos + shift) > 0 ? pos + shift : 0;
     }
 }
 


### PR DESCRIPTION
When I run:
subsync @-100 < myFile.srt > myNewFile.srt
And lines start earlier than 00:01:40,000 (100 seconds), then I end up with negative numbers. In the video player I was using, this was causing very odd behavior. (It may have been a bad/weird video player because I'm having trouble recreating it now)

For instance
00:00:02,135 --> 00:00:04,770 set back 100 seconds gave me
0-1:58:22,135 --> 0-1:58:24,770

00:00:00,000 --> 00:00:00,000 doesn't cause any problems for me and I think makes more sense in general for subtitles that aren't utilized by your video.